### PR TITLE
Update website format JSON of Kaiju Token

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -628,7 +628,7 @@
    "address":   "0x4f909dFE5Daaf94fbd1fD4C2E582F7608C87cd94",
    "symbol":    "KAIJU",
    "image":      "https://marketcap.cash/kaiju.png",
-   "website":   "https://kaiju.cash",
+   "websites": ["https://kaiju.cash"],
    "telegram": "https://t.me/KaiJuTheShitcoinKiller",
    "twitter":     "https://twitter.com/KaijuCash"
 },


### PR DESCRIPTION
Website fields in Kaiju JSON is wrong
So, i update from
"website": "https://kaiju.cash"
to
"websites": ["https://kaiju.cash"]